### PR TITLE
Updating mbed-os to mbed-os-5.11.1

### DIFF
--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,2 +1,2 @@
-https://github.com/ARMmbed/mbed-os/#51d55508e8400b60af467005646c4e2164738d48
+https://github.com/ARMmbed/mbed-os/#c966348d3f9ca80843be7cdc9b748f06ea73ced0
 


### PR DESCRIPTION
Please test this PR

If successful then merge, otherwise provide a known issue.
Once you get notification of the release being made public then tag Master with mbed-os-5.11.1 . 